### PR TITLE
Fix build with newer Hackage packages

### DIFF
--- a/accelerate.cabal
+++ b/accelerate.cabal
@@ -357,7 +357,7 @@ library
         , microlens                     >= 0.4
         , microlens-th                  >= 0.4
         , microlens-mtl                 >= 0.2
-        , MIP                           >= 0.1.1
+        , MIP                           >= 0.2
         , mtl                           >= 2.0
         , prettyprinter                 >= 1.7
         , prettyprinter-ansi-terminal   >= 1.1.2

--- a/src/Data/Array/Accelerate/Test/NoFib/Issues/Issue436.hs
+++ b/src/Data/Array/Accelerate/Test/NoFib/Issues/Issue436.hs
@@ -18,7 +18,7 @@ module Data.Array.Accelerate.Test.NoFib.Issues.Issue436 (
 
 ) where
 
-import Data.Array.Accelerate                              as A
+import Data.Array.Accelerate                              as A hiding (test)
 import Data.Array.Accelerate.Test.NoFib.Base
 
 import Test.Tasty

--- a/src/Data/Array/Accelerate/Trafo.hs
+++ b/src/Data/Array/Accelerate/Trafo.hs
@@ -54,6 +54,12 @@ import qualified Data.Array.Accelerate.Trafo.Operation.LiveVars as Operation
 import qualified Data.Array.Accelerate.Trafo.Operation.Simplify as Operation
 -- import qualified Data.Array.Accelerate.Trafo.Vectorise    as Vectorise
 
+#ifdef ACCELERATE_DEBUG
+import Data.Array.Accelerate.Debug.Internal
+import Formatting
+import System.IO.Unsafe (unsafePerformIO)
+#endif
+
 import Control.DeepSeq
 import qualified Data.Array.Accelerate.Trafo.Partitioning.ILP.Graph as Partitioning
 import Data.Array.Accelerate.Representation.Ground (DesugaredArrays, DesugaredAfun)

--- a/src/Data/Array/Accelerate/Trafo/Partitioning/ILP/Labels.hs
+++ b/src/Data/Array/Accelerate/Trafo/Partitioning/ILP/Labels.hs
@@ -34,7 +34,8 @@ import Data.Array.Accelerate.Error
 import qualified Data.Set as S
 
 import Lens.Micro.TH ( makeLenses )
-import Control.Monad.State ( (>=>), State )
+import Control.Monad ((>=>))
+import Control.Monad.State ( State )
 import Lens.Micro.Mtl ((<%=))
 import qualified Data.Map as M
 import Lens.Micro ((^.))

--- a/src/Data/Array/Accelerate/Trafo/Partitioning/ILP/MIP.hs
+++ b/src/Data/Array/Accelerate/Trafo/Partitioning/ILP/MIP.hs
@@ -56,8 +56,7 @@ instance (MakesILP op, MIP.IsSolver s IO) => ILPSolver (MIP s) op where
         <*> cons n constr
         <*> pure [] 
         <*> pure [] 
-        <*> vartypes -- If any variables are not given a type, they won't get fixed by `solveCondensedSoluton` (and I'm also not sure whether Integer is the default).
-        <*> bounds bnds 
+        <*> (M.map (IntegerVariable,) <$> bounds bnds)
       problem = runReader readerProblem names
 
       -- varsOf :: [MIP.Constraint Scientific] -> [MIP.Var]
@@ -65,8 +64,6 @@ instance (MakesILP op, MIP.IsSolver s IO) => ILPSolver (MIP s) op where
 
       mkFun Maximise = ObjectiveFunction (Just "AccelerateObjective") OptMax
       mkFun Minimise = ObjectiveFunction (Just "AccelerateObjective") OptMin
-
-      vartypes = allIntegers -- assuming that all variables have bounds
 
 
       -- addZeroes :: MIP.Problem Scientific -> MIP.Solution Scientific -> MIP.Solution Scientific
@@ -114,9 +111,6 @@ bounds NoBounds = pure mempty
 -- extraConstraints = do
 --   vs <- asks $ map toVar . M.keys . fst
 --   return [MIP.constExpr (-5) MIP..<=. MIP.varExpr x | x <- vs]
-
-allIntegers :: Reader (Names op) (M.Map MIP.Var VarType)
-allIntegers = asks $ M.fromList . map ((,IntegerVariable) . toVar) . M.keys . fst 
 
 
 

--- a/src/Data/Array/Accelerate/Trafo/Partitioning/ILP/Solve.hs
+++ b/src/Data/Array/Accelerate/Trafo/Partitioning/ILP/Solve.hs
@@ -24,6 +24,7 @@ import Data.Function ( on )
 import Lens.Micro ((^.),  _1 )
 import Lens.Micro.Extras ( view )
 import Data.Maybe (fromJust,  mapMaybe )
+import Control.Monad (forM, replicateM)
 import Control.Monad.State
 import Data.Array.Accelerate.Trafo.Partitioning.ILP.NameGeneration (freshName)
 import Data.Foldable

--- a/src/Data/Array/Accelerate/Trafo/Schedule/Uniform.hs
+++ b/src/Data/Array/Accelerate/Trafo/Schedule/Uniform.hs
@@ -58,7 +58,7 @@ import qualified Data.Array.Accelerate.AST.Partitioned as C
 import Data.Maybe
 import Prelude hiding (id, (.), read)
 import Control.Category
-import Control.DeepSeq
+import Control.DeepSeq hiding (Unit(..))
 import Control.Concurrent
 import Data.IORef
 import System.IO.Unsafe (unsafePerformIO)

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,11 +11,7 @@ extra-deps:
 - OptDir-0.0.4
 - bytestring-encoding-0.1.2.0
 - fclabels-2.0.5.1
-# - MIP-0.1.1.0
-- github: msakai/haskell-MIP
-  commit: 4295aa21a24a30926b55770c55ac00f749fb8a39
-  subdirs:
-  - MIP
+- MIP-0.2.0.0
 
 
 


### PR DESCRIPTION
This improves compatibility with latest Hackage releases of some packages, so that the library builds with cabal on newer GHC versions. It also attempts to improve the build status with +debug and +nofib, although the test suite does not build completely yet.