### PR TITLE
HLS fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 *.hi
 *.o
 /gurobi.log
+/.vscode

--- a/src/Data/Array/Accelerate/Array/Buffer.hs
+++ b/src/Data/Array/Accelerate/Array/Buffer.hs
@@ -119,6 +119,9 @@ foreign import ccall unsafe "&accelerate_buffer_release" memoryReleaseRef :: Fun
 memoryAlloc :: Word64 -> IO (Ptr ())
 memoryAlloc = undefined
 
+memoryByteSize :: Ptr () -> IO Word64
+memoryByteSize = undefined
+
 memoryRetain :: Ptr () -> IO ()
 memoryRetain = undefined
 


### PR DESCRIPTION
Fixed HLS not working after a recent commit.
+ Added missing declaration for memoryByteSize in __GHCIDE__ preprocessor branch.
