### PR TITLE
New pipeline Windows support

### DIFF
--- a/cbits/alloc.cpp
+++ b/cbits/alloc.cpp
@@ -1,10 +1,26 @@
+#ifdef _WIN32
+#include <cstdlib>
+#include <cstdint>
+#else
 #include "./parlaylib/include/parlay/alloc.h"
+#endif
 
 extern "C" {
+
   void* accelerate_raw_alloc(uint64_t size, uint64_t align) {
+#ifdef _WIN32
+    return _aligned_malloc(size, align);
+#else
     return parlay::p_malloc(size, align);
+#endif
   }
+
   void accelerate_raw_free(void *ptr) {
+#ifdef _WIN32
+    _aligned_free(ptr);
+#else
     parlay::p_free(ptr);
+#endif
   }
+
 }

--- a/cbits/alloc.cpp
+++ b/cbits/alloc.cpp
@@ -5,6 +5,11 @@
 #include "./parlaylib/include/parlay/alloc.h"
 #endif
 
+// Windows uses `_aligned_malloc` and `_aligned_free` from MinGW rather than ParlayLib.
+// ParlayLib should compile with MinGW, see: https://github.com/cmuparlay/parlaylib
+// But we have not gotten it to work.
+// TODO: Maybe try getting Parlaylib to work on windows.
+
 extern "C" {
 
   void* accelerate_raw_alloc(uint64_t size, uint64_t align) {


### PR DESCRIPTION
**Description**
Adds Windows support on the new pipeline.

**Motivation and context**
The new pipeline did not work on Windows.

**How has this been tested?**
The following benchmarks were run on several Windows machines using clang 19 and CBC 2.10.
**NOTE**: Cuda support has not been tested.

- _MG_ from: [CFAL-bench-new-accelerate](https://github.com/ivogabe/CFAL-bench-new-accelerate)
- _nbody-naive_ from: [CFAL-bench-new-accelerate](https://github.com/ivogabe/CFAL-bench-new-accelerate)
- _quickhull_ from: [quickhull-benchmarks](https://github.com/ivogabe/quickhull-benchmarks)

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed