### PR TITLE
Add `select`

### DIFF
--- a/src/Data/Array/Accelerate.hs
+++ b/src/Data/Array/Accelerate.hs
@@ -374,7 +374,7 @@ module Data.Array.Accelerate (
   fst, afst, snd, asnd, curry, uncurry,
 
   -- *** Flow control
-  (?), match, cond, while, iterate,
+  (?), match, cond, select, while, iterate,
   Assert(assert, assertMessage),
 
   -- *** Scalar reduction

--- a/src/Data/Array/Accelerate/AST/Exp.hs
+++ b/src/Data/Array/Accelerate/AST/Exp.hs
@@ -171,6 +171,12 @@ data PreOpenExp arr env t where
                 -> PreOpenExp arr env t
                 -> PreOpenExp arr env t
 
+  -- Conditional expression that chooses one value based on the condition without branching.
+  Select        :: PreOpenExp arr env PrimBool
+                -> PreOpenExp arr env t
+                -> PreOpenExp arr env t
+                -> PreOpenExp arr env t
+
   Assert        :: Text
                 -> PreOpenExp arr env PrimBool
                 -> PreOpenExp arr env t
@@ -385,6 +391,7 @@ expType = \case
   Case _ [] (Just e)           -> expType e
   Case{}                       -> internalError "empty case encountered"
   Cond _ e _                   -> expType e
+  Select _ e _                 -> expType e
   While _ (Lam lhs _) _        -> lhsToTupR lhs
   While{}                      -> internalError "What's the matter, you're running in the shadows"
   Const tR _                   -> TupRsingle tR
@@ -515,6 +522,7 @@ rnfOpenExp topExp =
     FromIndex shr sh ix       -> rnfShapeR shr `seq` rnfE sh `seq` rnfE ix
     Case e rhs def            -> rnfE e `seq` rnfList (\(t,c) -> t `seq` rnfE c) rhs `seq` rnfMaybe rnfE def
     Cond p e1 e2              -> rnfE p `seq` rnfE e1 `seq` rnfE e2
+    Select p e1 e2            -> rnfE p `seq` rnfE e1 `seq` rnfE e2
     While p f x               -> rnfF p `seq` rnfF f `seq` rnfE x
     PrimApp f x               -> rnfPrimFun f `seq` rnfE x
     ArrayInstr arr e          -> rnfArrayInstr arr `seq` rnfE e
@@ -639,6 +647,7 @@ liftOpenExp pexp =
     FromIndex shr sh ix       -> [|| FromIndex $$(liftShapeR shr) $$(liftE sh) $$(liftE ix) ||]
     Case p rhs def            -> [|| Case $$(liftE p) $$(liftList (\(t,c) -> [|| (t, $$(liftE c)) ||]) rhs) $$(liftMaybe liftE def) ||]
     Cond p t e                -> [|| Cond $$(liftE p) $$(liftE t) $$(liftE e) ||]
+    Select p t e              -> [|| Select $$(liftE p) $$(liftE t) $$(liftE e) ||]
     While p f x               -> [|| While $$(liftF p) $$(liftF f) $$(liftE x) ||]
     PrimApp f x               -> [|| PrimApp $$(liftPrimFun f) $$(liftE x) ||]
     ArrayInstr arr x          -> [|| ArrayInstr $$(liftArrayInstr arr) $$(liftE x) ||]
@@ -757,6 +766,7 @@ formatExpOp = later $ \case
   FromIndex{}     -> "FromIndex"
   Case{}          -> "Case"
   Cond{}          -> "Cond"
+  Select{}        -> "Select"
   While{}         -> "While"
   PrimApp{}       -> "PrimApp"
   ArrayInstr ar _ -> fromString $ showArrayInstrOp ar

--- a/src/Data/Array/Accelerate/Analysis/Hash/Exp.hs
+++ b/src/Data/Array/Accelerate/Analysis/Hash/Exp.hs
@@ -176,6 +176,7 @@ encodeOpenExp exp =
     FromIndex _ sh i            -> intHost $(hashQ "FromIndex")   <> travE sh <> travE i
     Case e rhs def              -> intHost $(hashQ "Case")        <> travE e  <> mconcat [ word8 t <> travE c | (t,c) <- rhs ] <> encodeMaybe travE def
     Cond c t e                  -> intHost $(hashQ "Cond")        <> travE c  <> travE t  <> travE e
+    Select c t e                -> intHost $(hashQ "Select")      <> travE c  <> travE t  <> travE e
     While p f x                 -> intHost $(hashQ "While")       <> travF p  <> travF f  <> travE x
     PrimApp f x                 -> intHost $(hashQ "PrimApp")     <> encodePrimFun f <> travE x
     ArrayInstr arr e            -> intHost $(hashQ "ArrayInstr")  <> encodeArrayInstr arr <> travE e

--- a/src/Data/Array/Accelerate/Interpreter.hs
+++ b/src/Data/Array/Accelerate/Interpreter.hs
@@ -849,6 +849,14 @@ evalOpenExp pexp env arr@(EvalArrayInstr runArrayInstr) =
       !v <- evalE c
       if toBool v then evalE t else evalE e
 
+    -- TODO(Daniel): should the interpreter also be branchless?
+    Select c t e -> do
+      !v <- evalE c
+      -- evaluate both branches
+      let !t' = evalE t
+      let !e' = evalE e
+      if toBool v then t' else e'
+
     While cond body seed ->
       evalE seed >>= go
       where

--- a/src/Data/Array/Accelerate/Interpreter.hs
+++ b/src/Data/Array/Accelerate/Interpreter.hs
@@ -849,7 +849,6 @@ evalOpenExp pexp env arr@(EvalArrayInstr runArrayInstr) =
       !v <- evalE c
       if toBool v then evalE t else evalE e
 
-    -- TODO(Daniel): should the interpreter also be branchless?
     Select c t e -> do
       !v <- evalE c
       -- evaluate both branches

--- a/src/Data/Array/Accelerate/Interpreter/Simple.hs
+++ b/src/Data/Array/Accelerate/Interpreter/Simple.hs
@@ -938,7 +938,6 @@ evalOpenExp pexp runarr env =
       | toBool (evalE c)        -> evalE t
       | otherwise               -> evalE e
 
-    -- TODO(Daniel): should the interpreter also be branchless?
     Select c t e ->
       -- evaluate both branches
       let !t' = evalE t

--- a/src/Data/Array/Accelerate/Interpreter/Simple.hs
+++ b/src/Data/Array/Accelerate/Interpreter/Simple.hs
@@ -938,6 +938,13 @@ evalOpenExp pexp runarr env =
       | toBool (evalE c)        -> evalE t
       | otherwise               -> evalE e
 
+    -- TODO(Daniel): should the interpreter also be branchless?
+    Select c t e ->
+      -- evaluate both branches
+      let !t' = evalE t
+          !e' = evalE e
+      in if toBool (evalE c) then t' else e'
+
     While cond body seed        -> go (evalE seed)
       where
         f       = evalF body

--- a/src/Data/Array/Accelerate/Language.hs
+++ b/src/Data/Array/Accelerate/Language.hs
@@ -88,7 +88,7 @@ module Data.Array.Accelerate.Language (
 
   -- * Flow-control
   acond, awhile,
-  cond,  while,
+  cond, select, while,
   Assert(..), assertBounds,
 
   -- * Utilities for bounds and shape checks
@@ -1295,6 +1295,15 @@ cond :: Elt t
      -> Exp t                   -- ^ else-expression
      -> Exp t
 cond (Exp c) (Exp x) (Exp y) = mkExp $ Cond (mkCoerce' c) x y
+
+-- | A scalar-level conditional expression
+-- that chooses one value based on the condition without branching.
+select :: (Elt t)
+       => Exp Bool                -- ^ condition
+       -> Exp t                   -- ^ then-expression
+       -> Exp t                   -- ^ else-expression
+       -> Exp t
+select (Exp c) (Exp x) (Exp y) = mkExp $ Select (mkCoerce' c) x y
 
 -- | While construct. Continue to apply the given function, starting with the
 -- initial value, until the test function evaluates to 'False'.

--- a/src/Data/Array/Accelerate/Pretty/Exp.hs
+++ b/src/Data/Array/Accelerate/Pretty/Exp.hs
@@ -141,6 +141,7 @@ prettyPreOpenExp ctx prettyArrayInstr env exp =
                       , hang shiftwidth (sep [ then_, t' ])
                       , hang shiftwidth (sep [ else_, e' ]) ]
     --
+    Select p t e          -> ppF3 "select"      (ppE p) (ppE t) (ppE e)
     ToIndex _ sh ix       -> ppF2 "toIndex"     (ppE sh) (ppE ix)
     FromIndex _ sh ix     -> ppF2 "fromIndex"   (ppE sh) (ppE ix)
     While p f x           -> ppF3 "while"       (ppF p) (ppF f) (ppE x)

--- a/src/Data/Array/Accelerate/Smart.hs
+++ b/src/Data/Array/Accelerate/Smart.hs
@@ -543,6 +543,11 @@ data PreSmartExp acc exp t where
                 -> exp t
                 -> PreSmartExp acc exp t
 
+  Select        :: exp PrimBool
+                -> exp t
+                -> exp t
+                -> PreSmartExp acc exp t
+
   While         :: TypeR t
                 -> (SmartExp t -> exp PrimBool)
                 -> (SmartExp t -> exp t)
@@ -901,6 +906,7 @@ instance HasTypeR exp => HasTypeR (PreSmartExp acc exp) where
     Case _ ((_,c):_)                -> typeR c
     Case{}                          -> internalError "encountered empty case"
     Cond _ e _                      -> typeR e
+    Select _ e _                    -> typeR e
     While t _ _ _                   -> t
     PrimApp f _                     -> snd $ primFunType f
     Index tp _ _                    -> tp
@@ -1417,6 +1423,7 @@ formatPreExpOp = later $ \case
   FromIndex{}   -> "FromIndex"
   Case{}        -> "Case"
   Cond{}        -> "Cond"
+  Select{}      -> "Select"
   While{}       -> "While"
   PrimApp{}     -> "PrimApp"
   Index{}       -> "Index"

--- a/src/Data/Array/Accelerate/Trafo/Exp/Shrink.hs
+++ b/src/Data/Array/Accelerate/Trafo/Exp/Shrink.hs
@@ -297,6 +297,7 @@ shrinkExp = Stats.substitution "shrinkE" . first getAny . shrinkE
       FromIndex shr sh i        -> FromIndex shr <$> shrinkE sh <*> shrinkE i
       Case e rhs def            -> Case <$> shrinkE e <*> sequenceA [ (t,) <$> shrinkE c | (t,c) <- rhs ] <*> shrinkMaybeE def
       Cond p t e                -> Cond <$> shrinkE p <*> shrinkE t <*> shrinkE e
+      Select p t e              -> Select <$> shrinkE p <*> shrinkE t <*> shrinkE e
       While p f x               -> While <$> shrinkF p <*> shrinkF f <*> shrinkE x
       PrimApp f x               -> PrimApp f <$> shrinkE x
       ArrayInstr arr e          -> ArrayInstr arr <$> shrinkE e
@@ -366,6 +367,7 @@ usesOfExp range = countE
       ToIndex _ sh e            -> countE sh <> countE e
       Case e rhs def            -> countE e  <> mconcat [ countE c | (_,c) <- rhs ] <> maybe (Finite 0) countE def
       Cond p t e                -> countE p  <> countE t <> countE e
+      Select p t e              -> countE p  <> countE t <> countE e
       While p f x               -> countE x  <> loopCount (usesOfFun range p) <> loopCount (usesOfFun range f)
       PrimApp _ x               -> countE x
       ArrayInstr _ e            -> countE e
@@ -396,6 +398,7 @@ arrayInstrsInExp = (`travE` [])
       FromIndex _ sh i           -> travE sh $ travE i acc
       Case e rhs def             -> travE e $ travAE rhs $ travME def acc
       Cond p t e                 -> travE p $ travE t $ travE e acc
+      Select p t e               -> travE p $ travE t $ travE e acc
       While p f x                -> travF p $ travF f $ travE x acc
       PrimApp _ x                -> travE x acc
       ArrayInstr arr e           -> Exists arr : travE e acc

--- a/src/Data/Array/Accelerate/Trafo/Exp/Simplify.hs
+++ b/src/Data/Array/Accelerate/Trafo/Exp/Simplify.hs
@@ -329,8 +329,8 @@ simplifyOpenExp env = first getAny . cvtE
       | Const _ 1 <- p                  = Stats.knownBranch "True"      (yes t')
       | Const _ 0 <- p                  = Stats.knownBranch "False"     (yes e')
       | Just Refl <- matchOpenExp t' e' = Stats.knownBranch "redundant" (yes e')
-      | PrimApp PrimLNot c <- p         = yes $ snd $ cond c e t
       | isCheap t' && isCheap e'        = yes $ snd $ select p t e
+      | PrimApp PrimLNot c <- p         = yes $ snd $ cond c e t
       | otherwise                       = Cond p <$> t <*> e
 
     isCheap :: PreOpenExp arr env t -> Bool

--- a/src/Data/Array/Accelerate/Trafo/Exp/Simplify.hs
+++ b/src/Data/Array/Accelerate/Trafo/Exp/Simplify.hs
@@ -307,19 +307,19 @@ simplifyOpenExp env = first getAny . cvtE
     shouldInline Const{} = True
     shouldInline _ = False
 
-    -- TODO(Daniel): comment
     select :: PreOpenExp arr env PrimBool
            -> (Any, PreOpenExp arr env t)
            -> (Any, PreOpenExp arr env t)
            -> (Any, PreOpenExp arr env t)
     select p t@(_,t') e@(_,e')
-      | Just Refl <- matchTypeR (expType t') (expType p)
-      , Const _ 0 <- e'
-      = yes $ PrimApp PrimLAnd (Pair p t')  -- p && t' = p ? t : 0
-      | Just Refl <- matchTypeR (expType e') (expType p)
-      , Const _ 1 <- t'
-      = yes $ PrimApp PrimLOr (Pair p e')   -- p || e' = p ? 1 : e
-      | otherwise = Select p <$> t <*> e
+      | Just Refl <- matchTypeR (expType t') (TupRsingle scalarTypeWord8)
+      = case (t', e') of
+        (_        , Const _ 0) -> yes $ PrimApp PrimLAnd (Pair p t')                    -- p ? t : 0 => p && t
+        (Const _ 0, _        ) -> yes $ PrimApp PrimLAnd (Pair (PrimApp PrimLNot p) e') -- p ? 0 : e => (not p) && e
+        (Const _ 1, _        ) -> yes $ PrimApp PrimLOr  (Pair p e')                    -- p ? 1 : e => p || e
+        (_        , Const _ 1) -> yes $ PrimApp PrimLOr  (Pair (PrimApp PrimLNot p) t') -- p ? t : 1 => (not p) || t
+        _                      -> Select p <$> t <*> e
+      | otherwise              =  Select p <$> t <*> e
 
     -- Simplify conditional expressions, in particular by eliminating branches
     -- when the predicate is a known constant.

--- a/src/Data/Array/Accelerate/Trafo/Exp/Simplify.hs
+++ b/src/Data/Array/Accelerate/Trafo/Exp/Simplify.hs
@@ -341,34 +341,56 @@ simplifyOpenExp env = first getAny . cvtE
         maxCost = 5
 
         calculateCost :: PreOpenExp arr env' t -> Maybe Int
-        calculateCost = goE
+        calculateCost = go
 
-        goE :: PreOpenExp arr env' t -> Maybe Int
-        goE exp =
+        go :: PreOpenExp arr env' t -> Maybe Int
+        go exp =
           case exp of
-            ArrayInstr a _        -> if inlineArrayInstr a
-                                      then Just 1
-                                      else Nothing
-            Evar{}                -> Just 1
-            Nil                   -> Just 1
-            Const{}               -> Just 1
-            Undef{}               -> Just 1
-            PrimApp{}             -> Just 1
-            Let _ bnd body        -> Just 1 .+. goE bnd .+. goE body
-            Pair e1 e2            -> Just 1 .+. goE e1  .+. goE e2
-            VecPack _ e           -> Just 1 .+. goE e
-            VecUnpack _ e         -> Just 1 .+. goE e
-            Coerce _ _ e          -> Just 1 .+. goE e
-            Assume e1 e2          -> Just 1 .+. goE e1  .+. goE e2
-            Foreign{}             -> Nothing
-            ToIndex{}             -> Nothing
-            FromIndex{}           -> Nothing
-            Case{}                -> Nothing
-            Cond{}                -> Nothing
-            Select{}              -> Nothing
-            While{}               -> Nothing
-            ShapeSize{}           -> Nothing
-            Assert{}              -> Nothing
+            ArrayInstr a _             -> if inlineArrayInstr a
+                                           then Just 1
+                                           else Nothing
+            Evar{}                     -> Just 1
+            Nil                        -> Just 1
+            Const{}                    -> Just 1
+            Undef{}                    -> Just 1
+
+            PrimApp (PrimAdd _) _      -> Just 1
+            PrimApp (PrimSub _) _      -> Just 1
+            PrimApp (PrimMul _) _      -> Just 1
+            PrimApp (PrimNeg _) _      -> Just 1
+            PrimApp (PrimAbs _) _      -> Just 1
+            PrimApp (PrimSig _) _      -> Just 1
+            PrimApp (PrimBAnd _) _     -> Just 1
+            PrimApp (PrimBOr _) _      -> Just 1
+            PrimApp (PrimBXor _) _     -> Just 1
+            PrimApp (PrimBNot _) _     -> Just 1
+            PrimApp (PrimBShiftL _) _  -> Just 1
+            PrimApp (PrimBShiftR _) _  -> Just 1
+            PrimApp (PrimBRotateL _) _ -> Just 1
+            PrimApp (PrimBRotateR _) _ -> Just 1
+            PrimApp (PrimCmp _ _) _    -> Just 1
+            PrimApp (PrimMax _) _      -> Just 1
+            PrimApp (PrimMin _) _      -> Just 1
+            PrimApp PrimLAnd _         -> Just 1
+            PrimApp PrimLOr _          -> Just 1
+            PrimApp PrimLNot _         -> Just 1
+            PrimApp{}                  -> Nothing
+
+            Let _ bnd body             -> Just 1 .+. go bnd .+. go body
+            Pair e1 e2                 -> Just 1 .+. go e1  .+. go e2
+            VecPack _ e                -> Just 1 .+. go e
+            VecUnpack _ e              -> Just 1 .+. go e
+            Coerce _ _ e               -> Just 1 .+. go e
+            Assume e1 e2               -> Just 1 .+. go e1  .+. go e2
+            Foreign{}                  -> Nothing
+            ToIndex{}                  -> Nothing
+            FromIndex{}                -> Nothing
+            Case{}                     -> Nothing
+            Cond{}                     -> Nothing
+            Select{}                   -> Nothing
+            While{}                    -> Nothing
+            ShapeSize{}                -> Nothing
+            Assert{}                   -> Nothing
 
         (.+.) :: Maybe Int -> Maybe Int -> Maybe Int
         a .+. b = (+) <$> a <*> b

--- a/src/Data/Array/Accelerate/Trafo/Exp/Simplify.hs
+++ b/src/Data/Array/Accelerate/Trafo/Exp/Simplify.hs
@@ -318,7 +318,16 @@ simplifyOpenExp env = first getAny . cvtE
       | Const _ 1 <- p                  = Stats.knownBranch "True"      (yes t')
       | Const _ 0 <- p                  = Stats.knownBranch "False"     (yes e')
       | Just Refl <- matchOpenExp t' e' = Stats.knownBranch "redundant" (yes e')
+      | isCheap t' && isCheap e'        = Select p <$> t <*> e
       | otherwise                       = Cond p <$> t <*> e
+
+    -- TODO(Daniel): when should we lower a cond to a select?
+    isCheap :: PreOpenExp arr env t -> Bool
+    isCheap e =
+      let s = summariseOpenExp e
+      in not (containsArrayInstr e)
+        && _ops s <= 3
+        && _terms s <= 5
 
     caseof :: PreOpenExp arr env TAG
            -> (Any, [(TAG, PreOpenExp arr env b)])
@@ -725,4 +734,34 @@ summariseOpenExp = (terms +~ 1) . goE
             PrimLNot                 -> zero
             PrimFromIntegral     i n -> travIntegralType i +++ travNumType n
             PrimToFloating       n f -> travNumType n +++ travFloatingType f
+
+containsArrayInstr :: PreOpenExp arr env t -> Bool
+containsArrayInstr = goE
+  where
+    goE :: PreOpenExp arr env t -> Bool
+    goE exp =
+      case exp of
+        ArrayInstr _ _        -> True
+        Let _ bnd body        -> goE bnd || goE body
+        Foreign _ _ _ x       -> goE x
+        Pair e1 e2            -> goE e1  || goE e2
+        VecPack _ e           -> goE e
+        VecUnpack _ e         -> goE e
+        ToIndex _ sh ix       -> goE sh  || goE ix
+        FromIndex _ sh ix     -> goE sh  || goE ix
+        Case e rhs (Just def) -> goE e   || any (goE . snd) rhs || goE def
+        Case e rhs Nothing    -> goE e   || any (goE . snd) rhs
+        Cond p t e            -> goE p   || goE t               || goE e
+        Select p t e          -> goE p   || goE t               || goE e
+        While p f x           -> goF p   || goF f               || goE x
+        ShapeSize _ sh        -> goE sh
+        PrimApp _ x           -> goE x
+        Coerce _ _ e          -> goE e
+        Assert e1 e2          -> goE e1  || goE e2
+        Assume e1 e2          -> goE e1  || goE e2
+        _                     -> False
+
+    goF :: PreOpenFun arr env f -> Bool
+    goF (Body e)  = goE e
+    goF (Lam _ f) = goF f
 

--- a/src/Data/Array/Accelerate/Trafo/Exp/Simplify.hs
+++ b/src/Data/Array/Accelerate/Trafo/Exp/Simplify.hs
@@ -332,16 +332,46 @@ simplifyOpenExp env = first getAny . cvtE
       | Const _ 1 <- p                  = Stats.knownBranch "True"      (yes t')
       | Const _ 0 <- p                  = Stats.knownBranch "False"     (yes e')
       | Just Refl <- matchOpenExp t' e' = Stats.knownBranch "redundant" (yes e')
-      | isCheap t' && isCheap e'        = yes $ Select p t' e'
+      | isCheap t' && isCheap e'        = yes $ snd $ select p t e
       | otherwise                       = Cond p <$> t <*> e
 
-    -- TODO(Daniel): when should we lower a cond to a select?
     isCheap :: PreOpenExp arr env t -> Bool
-    isCheap e =
-      let s = summariseOpenExp e
-      in not (containsArrayInstr e)
-        && _ops s <= 3
-        && _terms s <= 5
+    isCheap = maybe False (<= maxCost) . calculateCost
+      where
+        maxCost = 5
+
+        calculateCost :: PreOpenExp arr env' t -> Maybe Int
+        calculateCost = goE
+
+        goE :: PreOpenExp arr env' t -> Maybe Int
+        goE exp =
+          case exp of
+            ArrayInstr a _        -> if inlineArrayInstr a
+                                      then Just 1
+                                      else Nothing
+            Evar{}                -> Just 1
+            Nil                   -> Just 1
+            Const{}               -> Just 1
+            Undef{}               -> Just 1
+            PrimApp{}             -> Just 1
+            Let _ bnd body        -> Just 1 .+. goE bnd .+. goE body
+            Pair e1 e2            -> Just 1 .+. goE e1  .+. goE e2
+            VecPack _ e           -> Just 1 .+. goE e
+            VecUnpack _ e         -> Just 1 .+. goE e
+            Coerce _ _ e          -> Just 1 .+. goE e
+            Assume e1 e2          -> Just 1 .+. goE e1  .+. goE e2
+            Foreign{}             -> Nothing
+            ToIndex{}             -> Nothing
+            FromIndex{}           -> Nothing
+            Case{}                -> Nothing
+            Cond{}                -> Nothing
+            Select{}              -> Nothing
+            While{}               -> Nothing
+            ShapeSize{}           -> Nothing
+            Assert{}              -> Nothing
+
+        (.+.) :: Maybe Int -> Maybe Int -> Maybe Int
+        a .+. b = (+) <$> a <*> b
 
     caseof :: PreOpenExp arr env TAG
            -> (Any, [(TAG, PreOpenExp arr env b)])
@@ -748,34 +778,4 @@ summariseOpenExp = (terms +~ 1) . goE
             PrimLNot                 -> zero
             PrimFromIntegral     i n -> travIntegralType i +++ travNumType n
             PrimToFloating       n f -> travNumType n +++ travFloatingType f
-
-containsArrayInstr :: PreOpenExp arr env t -> Bool
-containsArrayInstr = goE
-  where
-    goE :: PreOpenExp arr env t -> Bool
-    goE exp =
-      case exp of
-        ArrayInstr _ _        -> True
-        Let _ bnd body        -> goE bnd || goE body
-        Foreign _ _ _ x       -> goE x
-        Pair e1 e2            -> goE e1  || goE e2
-        VecPack _ e           -> goE e
-        VecUnpack _ e         -> goE e
-        ToIndex _ sh ix       -> goE sh  || goE ix
-        FromIndex _ sh ix     -> goE sh  || goE ix
-        Case e rhs (Just def) -> goE e   || any (goE . snd) rhs || goE def
-        Case e rhs Nothing    -> goE e   || any (goE . snd) rhs
-        Cond p t e            -> goE p   || goE t               || goE e
-        Select p t e          -> goE p   || goE t               || goE e
-        While p f x           -> goF p   || goF f               || goE x
-        ShapeSize _ sh        -> goE sh
-        PrimApp _ x           -> goE x
-        Coerce _ _ e          -> goE e
-        Assert e1 e2          -> goE e1  || goE e2
-        Assume e1 e2          -> goE e1  || goE e2
-        _                     -> False
-
-    goF :: PreOpenFun arr env f -> Bool
-    goF (Body e)  = goE e
-    goF (Lam _ f) = goF f
 

--- a/src/Data/Array/Accelerate/Trafo/Exp/Simplify.hs
+++ b/src/Data/Array/Accelerate/Trafo/Exp/Simplify.hs
@@ -331,61 +331,59 @@ simplifyOpenExp env = first getAny . cvtE
       | otherwise                       = Cond p <$> t <*> e
 
     isCheap :: PreOpenExp arr env t -> Bool
-    isCheap = maybe False (<= maxCost) . calculateCost
+    isCheap = maybe False (<= maxCost) . expCost
       where
         maxCost = 5
 
-        calculateCost :: PreOpenExp arr env' t -> Maybe Int
-        calculateCost = go
+        expCost :: PreOpenExp arr env' t -> Maybe Int
+        expCost exp = case exp of
+          ArrayInstr a _   -> if inlineArrayInstr a
+                               then Just 1
+                               else Nothing
+          Evar{}           -> Just 1
+          Nil              -> Just 1
+          Const{}          -> Just 1
+          Undef{}          -> Just 1
+          PrimApp f e      -> primCost f .+. expCost e
+          Let _ bnd body   -> Just 1     .+. expCost bnd .+. expCost body
+          Pair e1 e2       -> Just 1     .+. expCost e1  .+. expCost e2
+          VecPack _ e      -> Just 1     .+. expCost e
+          VecUnpack _ e    -> Just 1     .+. expCost e
+          Coerce _ _ e     -> Just 1     .+. expCost e
+          Assume e1 e2     -> Just 1     .+. expCost e1  .+. expCost e2
+          Foreign{}        -> Nothing
+          ToIndex{}        -> Nothing
+          FromIndex{}      -> Nothing
+          Case{}           -> Nothing
+          Cond{}           -> Nothing
+          Select{}         -> Nothing
+          While{}          -> Nothing
+          ShapeSize{}      -> Nothing
+          Assert{}         -> Nothing
 
-        go :: PreOpenExp arr env' t -> Maybe Int
-        go exp =
-          case exp of
-            ArrayInstr a _             -> if inlineArrayInstr a
-                                           then Just 1
-                                           else Nothing
-            Evar{}                     -> Just 1
-            Nil                        -> Just 1
-            Const{}                    -> Just 1
-            Undef{}                    -> Just 1
-
-            PrimApp (PrimAdd _) _      -> Just 1
-            PrimApp (PrimSub _) _      -> Just 1
-            PrimApp (PrimMul _) _      -> Just 1
-            PrimApp (PrimNeg _) _      -> Just 1
-            PrimApp (PrimAbs _) _      -> Just 1
-            PrimApp (PrimSig _) _      -> Just 1
-            PrimApp (PrimBAnd _) _     -> Just 1
-            PrimApp (PrimBOr _) _      -> Just 1
-            PrimApp (PrimBXor _) _     -> Just 1
-            PrimApp (PrimBNot _) _     -> Just 1
-            PrimApp (PrimBShiftL _) _  -> Just 1
-            PrimApp (PrimBShiftR _) _  -> Just 1
-            PrimApp (PrimBRotateL _) _ -> Just 1
-            PrimApp (PrimBRotateR _) _ -> Just 1
-            PrimApp (PrimCmp _ _) _    -> Just 1
-            PrimApp (PrimMax _) _      -> Just 1
-            PrimApp (PrimMin _) _      -> Just 1
-            PrimApp PrimLAnd _         -> Just 1
-            PrimApp PrimLOr _          -> Just 1
-            PrimApp PrimLNot _         -> Just 1
-            PrimApp{}                  -> Nothing
-
-            Let _ bnd body             -> Just 1 .+. go bnd .+. go body
-            Pair e1 e2                 -> Just 1 .+. go e1  .+. go e2
-            VecPack _ e                -> Just 1 .+. go e
-            VecUnpack _ e              -> Just 1 .+. go e
-            Coerce _ _ e               -> Just 1 .+. go e
-            Assume e1 e2               -> Just 1 .+. go e1  .+. go e2
-            Foreign{}                  -> Nothing
-            ToIndex{}                  -> Nothing
-            FromIndex{}                -> Nothing
-            Case{}                     -> Nothing
-            Cond{}                     -> Nothing
-            Select{}                   -> Nothing
-            While{}                    -> Nothing
-            ShapeSize{}                -> Nothing
-            Assert{}                   -> Nothing
+        primCost :: PrimFun f -> Maybe Int
+        primCost f = case f of
+          (PrimAdd _)      -> Just 1
+          (PrimSub _)      -> Just 1
+          (PrimMul _)      -> Just 1
+          (PrimNeg _)      -> Just 1
+          (PrimAbs _)      -> Just 1
+          (PrimSig _)      -> Just 1
+          (PrimBAnd _)     -> Just 1
+          (PrimBOr _)      -> Just 1
+          (PrimBXor _)     -> Just 1
+          (PrimBNot _)     -> Just 1
+          (PrimBShiftL _)  -> Just 1
+          (PrimBShiftR _)  -> Just 1
+          (PrimBRotateL _) -> Just 1
+          (PrimBRotateR _) -> Just 1
+          (PrimCmp _ _)    -> Just 1
+          (PrimMax _)      -> Just 1
+          (PrimMin _)      -> Just 1
+          PrimLAnd         -> Just 1
+          PrimLOr          -> Just 1
+          PrimLNot         -> Just 1
+          _                -> Nothing
 
         (.+.) :: Maybe Int -> Maybe Int -> Maybe Int
         a .+. b = (+) <$> a <*> b

--- a/src/Data/Array/Accelerate/Trafo/Exp/Simplify.hs
+++ b/src/Data/Array/Accelerate/Trafo/Exp/Simplify.hs
@@ -311,9 +311,12 @@ simplifyOpenExp env = first getAny . cvtE
            -> (Any, PreOpenExp arr env t)
            -> (Any, PreOpenExp arr env t)
            -> (Any, PreOpenExp arr env t)
-    select p t e
-      | PrimApp PrimLNot c <- p = yes $ snd $ select c e t
-      | otherwise               =  Select p <$> t <*> e
+    select p t@(_,t') e@(_,e')
+      | Const _ 1 <- p                  = Stats.knownBranch "True"      (yes t')
+      | Const _ 0 <- p                  = Stats.knownBranch "False"     (yes e')
+      | Just Refl <- matchOpenExp t' e' = Stats.knownBranch "redundant" (yes e')
+      | PrimApp PrimLNot c <- p         = yes $ snd $ select c e t
+      | otherwise                       =  Select p <$> t <*> e
 
     -- Simplify conditional expressions, in particular by eliminating branches
     -- when the predicate is a known constant.

--- a/src/Data/Array/Accelerate/Trafo/Exp/Simplify.hs
+++ b/src/Data/Array/Accelerate/Trafo/Exp/Simplify.hs
@@ -314,12 +314,13 @@ simplifyOpenExp env = first getAny . cvtE
     select p t@(_,t') e@(_,e')
       | Just Refl <- matchTypeR (expType t') (TupRsingle scalarTypeWord8)
       = case (t', e') of
-        (_        , Const _ 0) -> yes $ PrimApp PrimLAnd (Pair p t')                    -- p ? t : 0 => p && t
-        (Const _ 0, _        ) -> yes $ PrimApp PrimLAnd (Pair (PrimApp PrimLNot p) e') -- p ? 0 : e => (not p) && e
-        (Const _ 1, _        ) -> yes $ PrimApp PrimLOr  (Pair p e')                    -- p ? 1 : e => p || e
-        (_        , Const _ 1) -> yes $ PrimApp PrimLOr  (Pair (PrimApp PrimLNot p) t') -- p ? t : 1 => (not p) || t
-        _                      -> Select p <$> t <*> e
-      | otherwise              =  Select p <$> t <*> e
+        (_        , Const _ 0)  -> yes $ PrimApp PrimLAnd (Pair p t')                    -- p ? t : 0 => p && t
+        (Const _ 0, _        )  -> yes $ PrimApp PrimLAnd (Pair (PrimApp PrimLNot p) e') -- p ? 0 : e => (not p) && e
+        (Const _ 1, _        )  -> yes $ PrimApp PrimLOr  (Pair p e')                    -- p ? 1 : e => p || e
+        (_        , Const _ 1)  -> yes $ PrimApp PrimLOr  (Pair (PrimApp PrimLNot p) t') -- p ? t : 1 => (not p) || t
+        _                       -> Select p <$> t <*> e
+      | PrimApp PrimLNot c <- p = yes $ snd $ select c e t
+      | otherwise               =  Select p <$> t <*> e
 
     -- Simplify conditional expressions, in particular by eliminating branches
     -- when the predicate is a known constant.
@@ -332,6 +333,7 @@ simplifyOpenExp env = first getAny . cvtE
       | Const _ 1 <- p                  = Stats.knownBranch "True"      (yes t')
       | Const _ 0 <- p                  = Stats.knownBranch "False"     (yes e')
       | Just Refl <- matchOpenExp t' e' = Stats.knownBranch "redundant" (yes e')
+      | PrimApp PrimLNot c <- p         = yes $ snd $ cond c e t
       | isCheap t' && isCheap e'        = yes $ snd $ select p t e
       | otherwise                       = Cond p <$> t <*> e
 

--- a/src/Data/Array/Accelerate/Trafo/Exp/Simplify.hs
+++ b/src/Data/Array/Accelerate/Trafo/Exp/Simplify.hs
@@ -311,14 +311,7 @@ simplifyOpenExp env = first getAny . cvtE
            -> (Any, PreOpenExp arr env t)
            -> (Any, PreOpenExp arr env t)
            -> (Any, PreOpenExp arr env t)
-    select p t@(_,t') e@(_,e')
-      | Just Refl <- matchTypeR (expType t') (TupRsingle scalarTypeWord8)
-      = case (t', e') of
-        (_        , Const _ 0)  -> yes $ PrimApp PrimLAnd (Pair p t')                    -- p ? t : 0 => p && t
-        (Const _ 0, _        )  -> yes $ PrimApp PrimLAnd (Pair (PrimApp PrimLNot p) e') -- p ? 0 : e => (not p) && e
-        (Const _ 1, _        )  -> yes $ PrimApp PrimLOr  (Pair p e')                    -- p ? 1 : e => p || e
-        (_        , Const _ 1)  -> yes $ PrimApp PrimLOr  (Pair (PrimApp PrimLNot p) t') -- p ? t : 1 => (not p) || t
-        _                       -> Select p <$> t <*> e
+    select p t e
       | PrimApp PrimLNot c <- p = yes $ snd $ select c e t
       | otherwise               =  Select p <$> t <*> e
 

--- a/src/Data/Array/Accelerate/Trafo/Exp/Simplify.hs
+++ b/src/Data/Array/Accelerate/Trafo/Exp/Simplify.hs
@@ -238,7 +238,7 @@ simplifyOpenExp env = first getAny . cvtE
       FromIndex shr sh ix       -> hoist2 (fromIndex shr) (cvtE sh) (cvtE ix)
       Case e rhs def            -> hoist (\e' -> caseof e' (sequenceA [ (t,) <$> cvtE c | (t,c) <- rhs ]) (cvtMaybeE def)) (cvtE e)
       Cond p t e                -> hoist (\p' -> cond p' (cvtE t) (cvtE e)) (cvtE p)
-      Select p t e              -> pure $ Select p t e
+      Select p t e              -> hoist (\p' -> select p' (cvtE t) (cvtE e)) (cvtE p)
       PrimApp f x               -> hoist (evalPrimApp env f) (cvtE x)
       ArrayInstr arr e          -> hoist (arrayInstr arr) (cvtE e)
       ShapeSize shr sh          -> hoist (shapeSize shr) (cvtE sh)
@@ -307,6 +307,20 @@ simplifyOpenExp env = first getAny . cvtE
     shouldInline Const{} = True
     shouldInline _ = False
 
+    -- TODO(Daniel): comment
+    select :: PreOpenExp arr env PrimBool
+           -> (Any, PreOpenExp arr env t)
+           -> (Any, PreOpenExp arr env t)
+           -> (Any, PreOpenExp arr env t)
+    select p t@(_,t') e@(_,e')
+      | Just Refl <- matchTypeR (expType t') (expType p)
+      , Const _ 0 <- e'
+      = yes $ PrimApp PrimLAnd (Pair p t')  -- p && t' = p ? t : 0
+      | Just Refl <- matchTypeR (expType e') (expType p)
+      , Const _ 1 <- t'
+      = yes $ PrimApp PrimLOr (Pair p e')   -- p || e' = p ? 1 : e
+      | otherwise = Select p <$> t <*> e
+
     -- Simplify conditional expressions, in particular by eliminating branches
     -- when the predicate is a known constant.
     --
@@ -318,7 +332,7 @@ simplifyOpenExp env = first getAny . cvtE
       | Const _ 1 <- p                  = Stats.knownBranch "True"      (yes t')
       | Const _ 0 <- p                  = Stats.knownBranch "False"     (yes e')
       | Just Refl <- matchOpenExp t' e' = Stats.knownBranch "redundant" (yes e')
-      | isCheap t' && isCheap e'        = Select p <$> t <*> e
+      | isCheap t' && isCheap e'        = yes $ Select p t' e'
       | otherwise                       = Cond p <$> t <*> e
 
     -- TODO(Daniel): when should we lower a cond to a select?

--- a/src/Data/Array/Accelerate/Trafo/Exp/Simplify.hs
+++ b/src/Data/Array/Accelerate/Trafo/Exp/Simplify.hs
@@ -339,7 +339,7 @@ simplifyOpenExp env = first getAny . cvtE
         maxCost = 5
 
         expCost :: PreOpenExp arr env' t -> Maybe Int
-        expCost exp = case exp of
+        expCost = \case
           ArrayInstr a _   -> if inlineArrayInstr a
                                then Just 1
                                else Nothing
@@ -365,24 +365,24 @@ simplifyOpenExp env = first getAny . cvtE
           Assert{}         -> Nothing
 
         primCost :: PrimFun f -> Maybe Int
-        primCost f = case f of
-          (PrimAdd _)      -> Just 1
-          (PrimSub _)      -> Just 1
-          (PrimMul _)      -> Just 1
-          (PrimNeg _)      -> Just 1
-          (PrimAbs _)      -> Just 1
-          (PrimSig _)      -> Just 1
-          (PrimBAnd _)     -> Just 1
-          (PrimBOr _)      -> Just 1
-          (PrimBXor _)     -> Just 1
-          (PrimBNot _)     -> Just 1
-          (PrimBShiftL _)  -> Just 1
-          (PrimBShiftR _)  -> Just 1
-          (PrimBRotateL _) -> Just 1
-          (PrimBRotateR _) -> Just 1
-          (PrimCmp _ _)    -> Just 1
-          (PrimMax _)      -> Just 1
-          (PrimMin _)      -> Just 1
+        primCost = \case
+          PrimAdd _        -> Just 1
+          PrimSub _        -> Just 1
+          PrimMul _        -> Just 1
+          PrimNeg _        -> Just 1
+          PrimAbs _        -> Just 1
+          PrimSig _        -> Just 1
+          PrimBAnd _       -> Just 1
+          PrimBOr _        -> Just 1
+          PrimBXor _       -> Just 1
+          PrimBNot _       -> Just 1
+          PrimBShiftL _    -> Just 1
+          PrimBShiftR _    -> Just 1
+          PrimBRotateL _   -> Just 1
+          PrimBRotateR _   -> Just 1
+          PrimCmp _ _      -> Just 1
+          PrimMax _        -> Just 1
+          PrimMin _        -> Just 1
           PrimLAnd         -> Just 1
           PrimLOr          -> Just 1
           PrimLNot         -> Just 1

--- a/src/Data/Array/Accelerate/Trafo/Exp/Simplify.hs
+++ b/src/Data/Array/Accelerate/Trafo/Exp/Simplify.hs
@@ -238,6 +238,7 @@ simplifyOpenExp env = first getAny . cvtE
       FromIndex shr sh ix       -> hoist2 (fromIndex shr) (cvtE sh) (cvtE ix)
       Case e rhs def            -> hoist (\e' -> caseof e' (sequenceA [ (t,) <$> cvtE c | (t,c) <- rhs ]) (cvtMaybeE def)) (cvtE e)
       Cond p t e                -> hoist (\p' -> cond p' (cvtE t) (cvtE e)) (cvtE p)
+      Select p t e              -> pure $ Select p t e
       PrimApp f x               -> hoist (evalPrimApp env f) (cvtE x)
       ArrayInstr arr e          -> hoist (arrayInstr arr) (cvtE e)
       ShapeSize shr sh          -> hoist (shapeSize shr) (cvtE sh)
@@ -652,6 +653,7 @@ summariseOpenExp = (terms +~ 1) . goE
         FromIndex _ sh ix     -> travE sh +++ travE ix
         Case e rhs def        -> travE e +++ mconcat [ travE c | (_,c) <- rhs ] +++ maybe zero travE def
         Cond p t e            -> travE p +++ travE t +++ travE e
+        Select p t e          -> travE p +++ travE t +++ travE e
         While p f x           -> travF p +++ travF f +++ travE x
         ArrayInstr a e        -> travA a +++ travE e
         ShapeSize _ sh        -> travE sh

--- a/src/Data/Array/Accelerate/Trafo/Exp/Substitution.hs
+++ b/src/Data/Array/Accelerate/Trafo/Exp/Substitution.hs
@@ -167,6 +167,7 @@ inlineVars lhsBound expr bound
       FromIndex shr e1 e2 -> FromIndex shr <$> travE e1 <*> travE e2
       Case e1 rhs def     -> Case <$> travE e1 <*> mapM (\(t,c) -> (t,) <$> travE c) rhs <*> travMaybeE def
       Cond e1 e2 e3       -> Cond <$> travE e1 <*> travE e2 <*> travE e3
+      Select e1 e2 e3     -> Select <$> travE e1 <*> travE e2 <*> travE e3
       While f1 f2 e1      -> While <$> travF f1 <*> travF f2 <*> travE e1
       Const t c           -> Just $ Const t c
       PrimApp p e1        -> PrimApp p <$> travE e1
@@ -460,6 +461,7 @@ rebuildOpenExp v exp =
     FromIndex shr sh ix -> FromIndex shr   <$> rebuildOpenExp v sh <*> rebuildOpenExp v ix
     Case e rhs def      -> Case            <$> rebuildOpenExp v e  <*> sequenceA [ (t,) <$> rebuildOpenExp v c | (t,c) <- rhs ] <*> rebuildMaybeExp v def
     Cond p t e          -> Cond            <$> rebuildOpenExp v p  <*> rebuildOpenExp v t  <*> rebuildOpenExp v e
+    Select p t e        -> Select          <$> rebuildOpenExp v p  <*> rebuildOpenExp v t  <*> rebuildOpenExp v e
     While p f x         -> While           <$> rebuildFun v p      <*> rebuildFun v f      <*> rebuildOpenExp v x
     PrimApp f x         -> PrimApp f       <$> rebuildOpenExp v x
     ArrayInstr arr e    -> ArrayInstr arr  <$> rebuildOpenExp v e
@@ -534,6 +536,7 @@ rebuildArrayInstrOpenExp v = \case
     FromIndex shr sh ix      -> FromIndex shr <$> travE sh <*> travE ix
     Case e rhs def           -> Case <$> travE e <*> sequenceA [ (t,) <$> travE c | (t,c) <- rhs ] <*> travME def
     Cond e1 e2 e3            -> Cond <$> travE e1 <*> travE e2 <*> travE e3
+    Select e1 e2 e3          -> Select <$> travE e1 <*> travE e2 <*> travE e3
     While c f x              -> While <$> travF c <*> travF f <*> travE x
     Const tp c               -> pure $ Const tp c
     PrimApp f x              -> PrimApp f <$> travE x

--- a/src/Data/Array/Accelerate/Trafo/Operation/Bounds.hs
+++ b/src/Data/Array/Accelerate/Trafo/Operation/Bounds.hs
@@ -342,10 +342,9 @@ boundsOptimizeExp env@(BoundsEnv _ _ zero _) expr = detectConst env $ case expr 
           isBoolBounds :: TermBounds (UniformEnv benv env) Word8 -> Bool
           isBoolBounds bounds
             | (TupRsingle bound) <- bounds
-            , (0, 1) <- getBoundRange (boundsZero env) TypeWord8
-                          (makeTransitive env bound)
-            = True
-            | otherwise = False
+            , (l, h) <- getBoundRange (boundsZero env) TypeWord8
+                                      (makeTransitive env bound)
+            = (l >= 0 && h <= 1) -- (0, 1) (0, 0) (1, 1)
 
           simplify
             | Just Refl <- matchTypeR (expType t') (TupRsingle scalarTypeWord8)

--- a/src/Data/Array/Accelerate/Trafo/Operation/Bounds.hs
+++ b/src/Data/Array/Accelerate/Trafo/Operation/Bounds.hs
@@ -326,6 +326,17 @@ boundsOptimizeExp env@(BoundsEnv _ _ zero _) expr = detectConst env $ case expr 
         ( unions (makeTransitives env trueBounds) (makeTransitives env falseBounds)
         , Cond c' true' false' )
 
+  Select c t f -> case travE c of
+    -- Check if the condition is already known based on the bounds analysis
+    Const _ 1 -> boundsOptimizeExp env t
+    Const _ 0 -> boundsOptimizeExp env f
+
+    c'
+      | (trueBounds, t') <- boundsOptimizeExp (assumeTrue env c') t
+      , (falseBounds, f') <- boundsOptimizeExp (assumeFalse env c') f ->
+        ( unions (makeTransitives env trueBounds) (makeTransitives env falseBounds)
+        , Select c' t' f' )
+
   Assert msg c body -> case travE c of
     Const _ 1 -> boundsOptimizeExp env body
     c'@(Const _ 0) -> Assert msg c' <$> boundsOptimizeExp env (undefs $ expType body)

--- a/src/Data/Array/Accelerate/Trafo/Operation/Bounds.hs
+++ b/src/Data/Array/Accelerate/Trafo/Operation/Bounds.hs
@@ -340,11 +340,10 @@ boundsOptimizeExp env@(BoundsEnv _ _ zero _) expr = detectConst env $ case expr 
                       (makeTransitives env falseBounds)
 
           isBoolBounds :: TermBounds (UniformEnv benv env) Word8 -> Bool
-          isBoolBounds bounds
-            | (TupRsingle bound) <- bounds
-            , (l, h) <- getBoundRange (boundsZero env) TypeWord8
-                                      (makeTransitive env bound)
-            = (l >= 0 && h <= 1) -- (0, 1) (0, 0) (1, 1)
+          isBoolBounds (TupRsingle bound) = (l >= 0 && h <= 1) -- (0, 1) (0, 0) (1, 1)
+            where
+              (l, h) = getBoundRange (boundsZero env) TypeWord8
+                                     (makeTransitive env bound)
 
           simplify
             | Just Refl <- matchTypeR (expType t') (TupRsingle scalarTypeWord8)

--- a/src/Data/Array/Accelerate/Trafo/Operation/Bounds.hs
+++ b/src/Data/Array/Accelerate/Trafo/Operation/Bounds.hs
@@ -332,8 +332,8 @@ boundsOptimizeExp env@(BoundsEnv _ _ zero _) expr = detectConst env $ case expr 
     Const _ 0 -> boundsOptimizeExp env f
 
     c'
-      | (trueBounds, t') <- boundsOptimizeExp (assumeTrue env c') t
-      , (falseBounds, f') <- boundsOptimizeExp (assumeFalse env c') f ->
+      | (trueBounds, t') <- boundsOptimizeExp env t
+      , (falseBounds, f') <- boundsOptimizeExp env f ->
         ( unions (makeTransitives env trueBounds) (makeTransitives env falseBounds)
         , Select c' t' f' )
 

--- a/src/Data/Array/Accelerate/Trafo/Operation/Bounds.hs
+++ b/src/Data/Array/Accelerate/Trafo/Operation/Bounds.hs
@@ -35,6 +35,7 @@ module Data.Array.Accelerate.Trafo.Operation.Bounds (
   boundsOptimizeFun, boundsOptimizeFun1, boundsOptimizeFun2, boundsOptimizeExp,
 ) where
 
+import Data.Array.Accelerate.AST.Exp
 import Data.Array.Accelerate.AST.Environment
 import qualified Data.Array.Accelerate.AST.Graph as Graph
 import Data.Array.Accelerate.AST.Idx
@@ -51,6 +52,7 @@ import Data.Array.Accelerate.Representation.Array
 import Data.Array.Accelerate.Representation.Type
 import Data.Array.Accelerate.Type
 import Data.Array.Accelerate.Error
+import Data.Array.Accelerate.Analysis.Match
 
 import Data.Array.Accelerate.Trafo.Operation.Bounds.Algebra
 import Data.Array.Accelerate.Trafo.Operation.Bounds.Environment
@@ -331,11 +333,32 @@ boundsOptimizeExp env@(BoundsEnv _ _ zero _) expr = detectConst env $ case expr 
     Const _ 1 -> boundsOptimizeExp env t
     Const _ 0 -> boundsOptimizeExp env f
 
-    c'
-      | (trueBounds, t') <- boundsOptimizeExp env t
-      , (falseBounds, f') <- boundsOptimizeExp env f ->
-        ( unions (makeTransitives env trueBounds) (makeTransitives env falseBounds)
-        , Select c' t' f' )
+    c' ->
+      let (trueBounds, t') = boundsOptimizeExp env t
+          (falseBounds, f') = boundsOptimizeExp env f
+          bs = unions (makeTransitives env trueBounds)
+                      (makeTransitives env falseBounds)
+
+          isBoolBounds :: TermBounds (UniformEnv benv env) Word8 -> Bool
+          isBoolBounds bounds
+            | (TupRsingle bound) <- bounds
+            , (0, 1) <- getBoundRange (boundsZero env) TypeWord8
+                          (makeTransitive env bound)
+            = True
+            | otherwise = False
+
+          simplify
+            | Just Refl <- matchTypeR (expType t') (TupRsingle scalarTypeWord8)
+            , isBoolBounds trueBounds
+            , isBoolBounds falseBounds
+            = case (t', f') of
+                (_        , Const _ 0)  -> (bs, PrimApp PrimLAnd (Pair c' t'))                    -- c ? t : 0 => c && t
+                (Const _ 0, _        )  -> (bs, PrimApp PrimLAnd (Pair (PrimApp PrimLNot c') f')) -- c ? 0 : f => (not c) && f
+                (Const _ 1, _        )  -> (bs, PrimApp PrimLOr  (Pair c' f'))                    -- c ? 1 : f => c || f
+                (_        , Const _ 1)  -> (bs, PrimApp PrimLOr  (Pair (PrimApp PrimLNot c') t')) -- c ? t : 1 => (not c) || t
+                _                       -> (bs, Select c' t' f')
+            | otherwise                 =  (bs, Select c' t' f')
+        in simplify
 
   Assert msg c body -> case travE c of
     Const _ 1 -> boundsOptimizeExp env body

--- a/src/Data/Array/Accelerate/Trafo/Partitioning/ILP/Labels.hs
+++ b/src/Data/Array/Accelerate/Trafo/Partitioning/ILP/Labels.hs
@@ -550,6 +550,9 @@ getExpDeps (Case poe1 poes poe2)            env = getExpDeps poe1 env <>
 getExpDeps (Cond poe1 poe2 exp3)            env = getExpDeps poe1 env <>
                                                   getExpDeps poe2 env <>
                                                   getExpDeps exp3 env
+getExpDeps (Select poe1 poe2 exp3)          env = getExpDeps poe1 env <>
+                                                  getExpDeps poe2 env <>
+                                                  getExpDeps exp3 env
 getExpDeps (While pof1 pof2 poe)            env = getFunDeps pof1 env <>
                                                   getFunDeps pof2 env <>
                                                   getExpDeps poe  env

--- a/src/Data/Array/Accelerate/Trafo/Sharing.hs
+++ b/src/Data/Array/Accelerate/Trafo/Sharing.hs
@@ -762,6 +762,7 @@ convertSharingExp config lyt alyt env aenv exp@(ScopedExp lams _) = cvt exp
           FromIndex shr sh e    -> AST.FromIndex shr (cvt sh) (cvt e)
           Case e rhs            -> cvtCase (cvt e) (over (mapped . _2) cvt rhs)
           Cond e1 e2 e3         -> AST.Cond (cvt e1) (cvt e2) (cvt e3)
+          Select e1 e2 e3       -> AST.Select (cvt e1) (cvt e2) (cvt e3)
           While tp p it i       -> AST.While (cvtFun1 tp p) (cvtFun1 tp it) (cvt i)
           PrimApp f e           -> cvtPrimFun f (cvt e)
           Index _ a e           -> AST.ArrayInstr (AST.Index $ cvtAvar a) (cvt e)
@@ -1869,6 +1870,7 @@ makeOccMapSharingExp config accOccMap expOccMap = travE
                                      (rhs', h2) <- unzip <$> sequence [ travE1 (t,) c | (t,c) <- rhs ]
                                      return (Case e' rhs', h1 `max` maximum h2 + 1)
             Cond e1 e2 e3       -> travE3 Cond e1 e2 e3
+            Select e1 e2 e3     -> travE3 Select e1 e2 e3
             While t p iter init -> do
                                      (p'   , h1) <- traverseFun1 lvl t p
                                      (iter', h2) <- traverseFun1 lvl t iter
@@ -2786,6 +2788,7 @@ determineScopesSharingExp config accOccMap expOccMap = scopesExp
                                        (rhs', accCount2) = unzip [ ((t,c'), counts)| (t,c) <- rhs, let (c', counts) = scopesExp c ]
                                     in reconstruct (Case e' rhs') (foldr (+++) accCount1 accCount2)
           Cond e1 e2 e3         -> travE3 Cond e1 e2 e3
+          Select e1 e2 e3       -> travE3 Select e1 e2 e3
           While tp p it i       -> let (p' , accCount1) = scopesFun1 p
                                        (it', accCount2) = scopesFun1 it
                                        (i' , accCount3) = scopesExp i


### PR DESCRIPTION
**Description**

Introduces a `select` function that chooses a value based on a condition without branching.
`select` is similar to `cond` except it evaluates both branches and picks the result without branching.

`cond` will automatically be simplified to a `select` when both branches are considered cheap, based on a simple cost heuristic.

`(&&)` and `(||)` are defined using if-then-else to enable short-circuiting. Using this new logic these can now get converted to a `select`, which then will be turned into a logical and/or.

The accelerate-llvm part: https://github.com/ivogabe/accelerate-llvm/pull/11

**How has this been tested?**
\-

**Types of changes**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

